### PR TITLE
Added options for :ignore_acknowledgement & :expect_transaction_error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby 
 rvm: 
- - 2.1.0 
- - 2.2.2 
+  - 2.3.0
+  - 2.4.1
 script: 
  - bundle exec origen -v 
  - bundle exec origen examples -c 

--- a/lib/origen_swd/driver.rb
+++ b/lib/origen_swd/driver.rb
@@ -68,7 +68,7 @@ module OrigenSWD
     def read(ap_dp, reg_or_val, options = {})
       addr = extract_address(reg_or_val, options.merge(use_reg_or_val_if_you_must: true))
       send_header(ap_dp, 1, addr)       # send read-specific header (rnw = 1)
-      receive_acknowledgement
+      receive_acknowledgement(options)
       receive_payload(reg_or_val, options)
       swd_dio.drive(0)
     end
@@ -177,11 +177,28 @@ module OrigenSWD
     end
 
     # Waits appropriate number of cycles for the acknowledgement phase
-    def receive_acknowledgement
+    # @param options [Hash] Options during acknowledgement reception.
+    # @option options [true, false] :ignore_acknowledgement Indicates that the acknowledgement
+    #   should not be checked for a pass/fail result. Rather, the tester will just be cycled 3 times.
+    # @option options [true, false] :expect_transaction_error Instead of verifying for a successful
+    #   transaction, verifies that a transaction error occurred.
+    # @note If both :ignore_acknowledgement and :expect_transaction_error are present,
+    #   :ignore_acknowledgement will take precedence.
+    def receive_acknowledgement(options = {})
       wait_trn
-      swd_dio.assert!(1)
-      swd_dio.assert!(0)
-      swd_dio.assert!(0)
+      if options[:ignore_acknowledgement]
+        log('Ignoring Acknowledgement Phase')
+        tester.cycle(3)
+      elsif options[:expect_transaction_error]
+        log('Expecting Error During Acknowledgement Phase')
+        swd_dio.assert!(0)
+        swd_dio.assert!(0)
+        swd_dio.assert!(1)
+      else
+        swd_dio.assert!(1)
+        swd_dio.assert!(0)
+        swd_dio.assert!(0)
+      end
       swd_dio.dont_care
     end
 


### PR DESCRIPTION
Had a need to verify that a transaction was failing. Added an option for that and threw a option in to just ignore the acknowledgement entirely, just in case.