### PR TITLE
Update method call for Ruby 3

### DIFF
--- a/lib/origen_swd/driver.rb
+++ b/lib/origen_swd/driver.rb
@@ -185,7 +185,8 @@ module OrigenSWD
     #   * [:success] (Default) -> Verify the acknowledgement as normal.
     # @param options [Hash] Placeholder for other/future options.
     # @raise [RuntimeError] When an unrecongized :confirm option is given.
-    def receive_acknowledgement(confirm: :success, **options)
+    def receive_acknowledgement(options={})
+      confirm = options[:confirm] || :success
       wait_trn
       if [:ignore, :none, :skip].include?(confirm)
         log('Ignoring Acknowledgement Phase')


### PR DESCRIPTION
Minor update to work with Ruby 3's [new rules](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) on args/kwargs.